### PR TITLE
Rely on Akamai REST CCUAPI

### DIFF
--- a/ipecache.gemspec
+++ b/ipecache.gemspec
@@ -18,5 +18,4 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'app_conf', '>= 0.4.0'
   gem.add_runtime_dependency 'choice', '>= 0.1.6'
   gem.add_runtime_dependency 'faraday_middleware', '>= 0.9.0'
-  gem.add_runtime_dependency 'savon', '>= 2.1.0'
 end


### PR DESCRIPTION
"[Akamai] CCU REST API is available for use immediately. New purge API implementations must use this API. Users of the SOAP-based CCUAPI must migrate to CCU REST API by June 1, 2014."

Doc is available at https://api.ccu.akamai.com/ccu/v2/docs/index.html
