### PR TITLE
plugin_puts_error should output failed urls along with the message

### DIFF
--- a/lib/ipecache/plugins/plugin.rb
+++ b/lib/ipecache/plugins/plugin.rb
@@ -59,7 +59,7 @@ module Ipecache
         if log_file
           File.open(log_file, 'a') { |file| file.write("#{Time.now.getutc} #{url} #{name}: #{message}\n") }
         end
-        puts "#{name}: #{message}"
+        puts "#{url} #{name}: #{message}"
       end
 
       private


### PR DESCRIPTION
ipecache don't show failed urls on stdout (only in log files). This very small fix align the behaviour inside plugin_puts_error.
