### PR TITLE
Add support of -n short option (alias of --no-fail), fix doc & indentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ ipecache [-f -u -c -p -l --status]
     * -c: Indicates that only CDN plugins should be run
     * -p: Indicates that only local proxy plugins should be run.
     * -l: Specify a file to log errors to
-    * --nofail: Do not quit on error, continue purging
+    * -n, --nofail: Do not quit on error, continue purging
 
 
 #### Example (Checking plugin status)

--- a/bin/ipecache
+++ b/bin/ipecache
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# ipecache - A command line memcached traffic analyzer
+# ipecache - Extensible tool for purging URLs from Caches and CDNs.
 #
 # Author:: Jon Cowie (<jcowie@etsy.com>)
 
@@ -48,9 +48,10 @@ Choice.options do
   end
 
   option :continue_on_error, :required => false do
-     long  '--nofail'
-     desc  'Continue on errors instead of exiting'
-   end
+    short '-n'
+    long  '--nofail'
+    desc  'Continue on errors instead of exiting'
+  end
 end
 
 if Choice.choices[:status]


### PR DESCRIPTION
Add support of -n short option (alias of --no-fail), fix doc & indentation.
