### PR TITLE
Akamai success progress uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ $>  ipecache -f ~/urlfile -c
 
    Ipecache::Plugins::Akamai: Beginning URL Purge from Akamai...
    Ipecache::Plugins::Akamai: Purging https://img.mydomain.com/image9.jpg
-   Ipecache::Plugins::Akamai: Purge successful!
+   Ipecache::Plugins::Akamai: Purge successful! [progressUri: https://api.ccu.akamai.com/ccu/v2/purges/xxxxxxxx-aaaa-1111-2222-bbbbbbbbbbbb]
    Ipecache::Plugins::Akamai: Purging https://img.mydomain.com/image10.jpg
    Ipecache::Plugins::Akamai: Purge successful!
 
@@ -169,9 +169,9 @@ $>  ipecache -f ~/urlfile
 
    Ipecache::Plugins::Akamai: Beginning URL Purge from Akamai...
    Ipecache::Plugins::Akamai: Purging https://img.mydomain.com/image9.jpg
-   Ipecache::Plugins::Akamai: Purge successful!
+   Ipecache::Plugins::Akamai: Purge successful! [progressUri: https://api.ccu.akamai.com/ccu/v2/purges/xxxxxxxx-aaaa-1111-2222-bbbbbbbbbbbb]
    Ipecache::Plugins::Akamai: Purging https://img.mydomain.com/image10.jpg
-   Ipecache::Plugins::Akamai: Purge successful!
+   Ipecache::Plugins::Akamai: Purge successful! [progressUri: https://api.ccu.akamai.com/ccu/v2/purges/xxxxxxxx-aaaa-1111-2222-bbbbbbbbbbbb]
 
    Ipecache::Plugins::Edgecast: Beginning URL Purge from Edgecast...
    Ipecache::Plugins::Edgecast: Purging https://img.mydomain.com/image9.jpg

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ $>  ipecache -f ~/urlfile -c
    Ipecache::Plugins::Akamai: Purging https://img.mydomain.com/image9.jpg
    Ipecache::Plugins::Akamai: Purge successful! [progressUri: https://api.ccu.akamai.com/ccu/v2/purges/xxxxxxxx-aaaa-1111-2222-bbbbbbbbbbbb]
    Ipecache::Plugins::Akamai: Purging https://img.mydomain.com/image10.jpg
-   Ipecache::Plugins::Akamai: Purge successful!
+   Ipecache::Plugins::Akamai: Purge successful! [progressUri: https://api.ccu.akamai.com/ccu/v2/purges/xxxxxxxx-aaaa-1111-2222-cccccccccccc]
 
    Ipecache::Plugins::Edgecast: Beginning URL Purge from Edgecast...
    Ipecache::Plugins::Edgecast: Purging https://img.mydomain.com/image9.jpg
@@ -169,9 +169,9 @@ $>  ipecache -f ~/urlfile
 
    Ipecache::Plugins::Akamai: Beginning URL Purge from Akamai...
    Ipecache::Plugins::Akamai: Purging https://img.mydomain.com/image9.jpg
-   Ipecache::Plugins::Akamai: Purge successful! [progressUri: https://api.ccu.akamai.com/ccu/v2/purges/xxxxxxxx-aaaa-1111-2222-bbbbbbbbbbbb]
+   Ipecache::Plugins::Akamai: Purge successful! [progressUri: https://api.ccu.akamai.com/ccu/v2/purges/xxxxxxxx-aaaa-1111-2222-dddddddddddd]
    Ipecache::Plugins::Akamai: Purging https://img.mydomain.com/image10.jpg
-   Ipecache::Plugins::Akamai: Purge successful! [progressUri: https://api.ccu.akamai.com/ccu/v2/purges/xxxxxxxx-aaaa-1111-2222-bbbbbbbbbbbb]
+   Ipecache::Plugins::Akamai: Purge successful! [progressUri: https://api.ccu.akamai.com/ccu/v2/purges/xxxxxxxx-aaaa-1111-2222-eeeeeeeeeeee]
 
    Ipecache::Plugins::Edgecast: Beginning URL Purge from Edgecast...
    Ipecache::Plugins::Edgecast: Purging https://img.mydomain.com/image9.jpg

--- a/lib/ipecache/plugins/akamai.rb
+++ b/lib/ipecache/plugins/akamai.rb
@@ -46,13 +46,14 @@ module Ipecache
 
           response_json = JSON.parse(response.body)
           response_httpStatus = response_json['httpStatus']
+          response_progressUri = response_json['progressUri']
 
           if response_httpStatus != 201
             plugin_puts_error(url,"Purge failed!")
             plugin_puts response.body
             exit 1 unless continue_on_error
           else
-            plugin_puts "Purge successful!"
+            plugin_puts "Purge successful! [progressUri: https://api.ccu.akamai.com#{response_progressUri}]"
           end
         end
       end


### PR DESCRIPTION
New Akamai API provides a way to track progression of submitted purge requests. This patch display tracking URLs along with success message.
Documentation updated accordingly.
