### PR TITLE
Fix API endpoint URL for SWISS TXT CDN plugin

### DIFF
--- a/lib/ipecache/plugins/swisstxt_cdn.rb
+++ b/lib/ipecache/plugins/swisstxt_cdn.rb
@@ -49,7 +49,7 @@ module Ipecache
           exit 1
         end
 
-        Faraday.new(url: config.url || 'https://cdn-api.swissttx.ch') do |conn|
+        Faraday.new(url: config.url || 'https://cdn-api.swisstxt.ch') do |conn|
           conn.request :url_encoded
           conn.headers[:user_agent]     = 'Ipecache'
           conn.headers[:accept]         = 'application/json'


### PR DESCRIPTION
Hi,

There is a small but nasty spelling error in the SWISS TXT CDN plugin.
I just corrected the API URL.

Thanks,
Nik
