### PR TITLE
Adds plugin for cloudfront invalidations

### DIFF
--- a/ipecache.gemspec
+++ b/ipecache.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'choice', '>= 0.1.6'
   gem.add_runtime_dependency 'faraday_middleware', '>= 0.9.0'
   gem.add_runtime_dependency 'public_suffix', '>= 1.4.2'
+  gem.add_runtime_dependency 'aws-sdk-v1', '>= 1.0'
 end

--- a/lib/ipecache/plugins/cloudfront.rb
+++ b/lib/ipecache/plugins/cloudfront.rb
@@ -1,0 +1,69 @@
+require 'ipecache/plugins/plugin'
+
+module Ipecache
+  module Plugins
+    class CloudFront < Plugin
+      name :cloudfront
+      hooks :cdn_purge
+
+      def perform
+        safe_require 'aws-sdk-v1'
+        safe_require 'uri'
+
+        access_key_id = config.access_key_id
+        secret_access_key = config.secret_access_key
+        region = config.region
+        distributions = config.distributions
+        batch_size = config.batch_size || 3000
+
+        if access_key_id.nil?
+          plugin_puts "Cloudfront access id not specified, Exiting..."
+          exit 1
+        end
+
+        if secret_access_key.nil?
+          plugin_puts "Cloudfront access key not specified, Exiting..."
+          exit 1
+        end
+
+        if distributions.nil?
+          plugin_puts "Cloudfront distributions not specified, Exiting..."
+          exit 1
+        end
+
+        if region.nil?
+          plugin_puts "Cloudfront region not specified, Exiting..."
+          exit 1
+        end
+
+        plugin_puts "Beginning URL Purge from CloudFront..."
+
+        AWS.config(
+        :access_key_id => access_key_id,
+        :secret_access_key => secret_access_key,
+        :region => region
+        )
+        cf = AWS::CloudFront.new()
+
+        urls.each_slice(batch_size) do |u|
+          paths = []
+          u.each { |x| paths << URI.parse(x).path}
+          distributions.each do |distri|
+            plugin_puts "Purging #{u.length} items from #{distri}"
+            result = cf.client.create_invalidation(
+              :distribution_id => distri,
+              :invalidation_batch => {
+                :paths => {
+                  :quantity => paths.length,
+                  :items => paths
+                },
+                :caller_reference => "Ipecache_#{Time.now}"
+              }
+            )
+            plugin_puts "#{result[:id]}: #{result[:status]}, #{result[:invalidation_batch][:paths][:items].length} item(s)"
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/Cloudfront.md
+++ b/plugins/Cloudfront.md
@@ -1,0 +1,46 @@
+CloudFront
+==========
+Purge URLs from the CloudFront CDN.
+
+Hooks
+-----
+- `cdn_purge`
+
+Configuration
+-------------
+```yaml
+plugins:
+  cloudfront:
+    access_key_id: yyyyyyyyyyyyyyyy
+    secret_access_key: xxxxxxxxxxxxxxxxxx
+    region: eu-west-1
+    batch_size: 3000
+    distributions:
+        - distribution1
+        - distribution2
+```
+
+#### access_key_id
+This is your aws access id
+
+- Type: `String`
+
+#### secret_access_key
+This is your aws access key
+
+- Type: `String`
+
+#### distributions
+This is a list of CF distributions
+
+- Type `Array`
+
+### region
+This is the AWS region of your CF distributions
+
+- Type `String`
+
+### batch_size
+This is the number of items to be included for each invalidation request, default to 3000 (aws max limit)
+
+- Type `Integer`


### PR DESCRIPTION
It uses the aws-sdk-v1, supports purging from multiple CF distributions
