### PR TITLE
Stop using deprecated Chef::REST, switch to ServerAPI

### DIFF
--- a/lib/ipecache/plugins/ats_chef.rb
+++ b/lib/ipecache/plugins/ats_chef.rb
@@ -18,7 +18,7 @@ module Ipecache
           exit 1
         elsif File.exists?(knife_file)
           Chef::Config.from_file(knife_file)
-          rest_api = Chef::REST.new(Chef::Config[:chef_server_url])
+          rest_api = Chef::ServerAPI.new(Chef::Config[:chef_server_url])
         else
           plugin_puts "Knife config file #{knife_file} doesn't exist."
           exit 1
@@ -39,7 +39,7 @@ module Ipecache
 
         urls.each do |u|
           url = u.chomp
-          plugin_puts ("Purging #{url}")
+          plugin_puts "Purging #{url}"
           nodes_ats_fqdns.each do |ats|
             hostname = URI.parse(url).host
             path = URI.parse(url).path


### PR DESCRIPTION
The ATSChef plugin is currently broken on any relatively recent version of Chef due to a deprecated call to Chef::REST. This switches out to Chef::ServerAPI.

Also I fixed a minor syntax issue.