### PR TITLE
update for akamai v3 api

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ plugins:
     secret: abc123
     zone: 1234
   akamai:
-    username: myusername
-    password: mypassword
+    client_secret: xxxxxxx
+    host: xxxxxxx
+    access_token: xxxxxxx
+    client_token: xxxxxxx
   cloudflare:
     login: foo@bar.com
     api_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/lib/ipecache/plugins/fastly.rb
+++ b/lib/ipecache/plugins/fastly.rb
@@ -9,7 +9,7 @@ module Ipecache
 
       def perform
         safe_require 'uri'
-
+        safe_require 'openssl'
         api_key = config.api_key
 
         if api_key.nil?

--- a/plugins/Akamai.md
+++ b/plugins/Akamai.md
@@ -11,8 +11,10 @@ Configuration
 ```yaml
 plugins:
   akamai:
-    username: foo
-    password: bar
+    client_secret: xxxxxxx
+    host: xxxxxxx
+    access_token: xxxxxxx
+    client_token: xxxxxxx
 ```
 
 #### username


### PR DESCRIPTION
The akamai v2 api has been deprecated and is no longer usable. This updates ipecache to use the akamai v3 api.